### PR TITLE
Created Prototype Makefiles for Project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-main.o
-*sfml-app
+*.o
+*therappeye
 build/

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Ubuntu, Debian:
 
 * Clone
 * Prerequisites
-* (linux) `g++ src/main.cpp src/presentation.cpp -o sfml-app -lsfml-graphics -lsfml-window -lsfml-system`. Then `./sfml-app`
+* (linux) `g++ src/main.cpp src/presentation.cpp -o therappeye -lsfml-graphics -lsfml-window -lsfml-system`. Then `./therappeye`
 
-> For CUDA-LAB: `nvcc src/<filename>.cu -o cusfml-app  -lsfml-graphics -lsfml-window -lsfml-system`. Then `./cusfml-app`
+> For CUDA-LAB: `nvcc src/<filename>.cu -o cuda-therappeye  -lsfml-graphics -lsfml-window -lsfml-system`. Then `./cuda-therappeye`
 
 Once running, press letter `n` from the keyboard to move to 'n'ext scene (exercise). Once you reach the end, press `q`  to 'quit' and terminate the program.
 

--- a/README.md
+++ b/README.md
@@ -25,23 +25,53 @@ Here are some general exercises that we may cover:
 
 To use this engine, simply compile and run the `main.cpp` file located in the `src` directory.
 
+## Compiling for MacOS with provided Makefiles
+
+If you are using MacOs along with having installed the `frameworks` for `SFML` (as suggested by their website):
+
+* open a terminal.
+* `cd` into `therappeye` folder.
+* run command `make therappeye -f makeMac.mk`. The `-f` argument tells `make` which `makefile` to use.
+* for now (08/09/2023) some warnings will be generated but program will compile.
+* run command `./therappeye` to start program.
+
+If you would like to clean the directory (remove object files, debug symbols), use command `make clean -f makeMac.mk` in the `therappeye` folder.
+
+If you would like to remove the executable, use the command `rm -f therappeye` in the `therappeye` folder.
+
+## Compiling for a Unix/Linux based platform with Provided Makefiles
+
+If you are using a Unix/Linux based platform, which includes `Windows Subset for Linux (WSL)` on Windows and VSCode's integrated `bash` terminal. And have installed the `libraries` for `SFML`, do the following:
+
+* open a terminal.
+* `cd` into `therappeye` folder.
+* run command `make therappeye -f makeUnix.mk`. The `-f` argument tells `make` which `makefile` to use.
+* for now (08/09/2023) some warnings will be generated but program will compile.
+* run command `./therappeye` to start program.
+
+If you would like to clean the directory (remove object files, debug symbols), use command `make clean -f makeUnix.mk` in the `therappeye` folder.
+
+If you would like to remove the executable, use the command `rm -f therappeye` in the `therappeye` folder.
+
 ## Prerequisites
 
 In Linux, make sure you have:
 
 Ubuntu, Debian:
+
 * `sudo apt-get install libsfml-dev`
 
 > **Devcontainer:** the development container image takes care of `libsfml-dev` library installation. If you choose such dev scenario, the prereq will be satisfied already.
 
 ## How to run
+
 * Clone
 * Prerequisites
 * (linux) `g++ src/main.cpp src/presentation.cpp -o sfml-app -lsfml-graphics -lsfml-window -lsfml-system`. Then `./sfml-app`
 
 > For CUDA-LAB: `nvcc src/<filename>.cu -o cusfml-app  -lsfml-graphics -lsfml-window -lsfml-system`. Then `./cusfml-app`
 
-Once running, press letter `n` from the keyboard to move to 'n'ext scene (exercise). Once you reach the end, press `q`  to 'q'uit and terminate the program.
+Once running, press letter `n` from the keyboard to move to 'n'ext scene (exercise). Once you reach the end, press `q`  to 'quit' and terminate the program.
 
 ## Contributing
 

--- a/makeMac.mk
+++ b/makeMac.mk
@@ -1,0 +1,38 @@
+#
+# Makefile for MacOS platforms using the SFML Frameworks
+#
+# Created By: David J Tinley
+# For: movement-disorders/therappeye application by https://github.com/luisgizirian
+#
+# Last Updated: 08/09/2023
+#
+
+# Variables
+CXX = clang++
+CXX_FLAGS = -g -Wall -std=c++17
+FRAMEWORK = -F /Library/Frameworks
+FRAMEWORK_OPTS = -framework sfml-window -framework sfml-graphics -framework sfml-system
+
+# Message ##############################################################################
+msg:
+	@echo 'Makefile for MacOS using SFML frameworks.'
+	@echo 'Use command "make therappeye -f makeMac.mk" to compile therappeye for MacOS.'
+#########################################################################################
+
+# Compile therappeye ####################################################################
+therappeye: presentation.o main.o
+	${CXX} ${CXX_FLAGS} presentation.o main.o -o therappeye ${FRAMEWORK} ${FRAMEWORK_OPTS}
+
+presentation.o:
+	${CXX} ${CXX_FLAGS} -c src/presentation.cpp
+
+main.o:
+	${CXX} ${CXX_FLAGS} -c src/main.cpp
+#########################################################################################
+
+# clean folder ##########################################################################
+clean:
+	rm -f *.o
+	rm -rf *.dSYM/
+	rm -f therappeye
+#########################################################################################

--- a/makeUnix.mk
+++ b/makeUnix.mk
@@ -1,0 +1,34 @@
+#
+# Makefile for Unix/Linux platforms using the SFML Libraries
+#
+# Created By: David J Tinley
+# For: movement-disorders/therappeye application by https://github.com/luisgizirian
+#
+# Last Updated: 08/09/2023
+#
+
+# Variables
+CXX = g++
+CXX_FLAGS = -g -Wall -std=c++17
+LIBRARIES = -lsfml-window -lsfml-graphics -lsfml-system
+
+# Message
+msg:
+	@echo 'Makefile for Unix based platforms using SFML libraries.'
+	@echo 'Use command "make therappeye -f makeUnix.mk" to compile therappeye for a Unix based platform.'
+	@echo 'Use command "make clean -f makeUnix.mk" to clean the project folder.'
+
+# Compile therappeye
+therappeye: presentation.o main.o
+	${CXX} ${CXX_FLAGS} presentation.o main.o -o therappeye ${LIBRARIES}
+
+presentation.o:
+	${CXX} ${CXX_FLAGS} -c src/presentation.cpp
+
+main.o:
+	${CXX} ${CXX_FLAGS} -c src/main.cpp
+
+clean:
+	rm -f *.o
+	rm -rf *.dSYM/
+	rm -f therappeye


### PR DESCRIPTION
Hi @luisgizirian , I have made 2 prototype makefiles for compiling this project. One is for MacOS's using the SFML `frameworks` and the other is for Unix/Linux based platforms that use the SFML libraries like `-lsfml-window`. I am not able to test the Linux makefile but I can confirm it builds and runs `therappeye` using the MacOS makefile. If this is something you are interested incorporating to the project, would you be able to test the Linux makefile? I figured these makefiles could simplify building during work on the real issues for the project. I also updated the `README.md` with the instructions for using the makefiles for different platforms. Thank you and have a good day!